### PR TITLE
test: final LLM review probe on terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ scripts/bin/
 # Compiled Go binaries in config directories
 **/config/entrypoint-patch
 **/config/*.exe
+
+<!-- LLM final probe 1777812018 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,3 +138,5 @@ make security             # tflint + checkov security scan
 - CI runner: GitLab shared runners + self-hosted on LXC 101 for Proxmox. PR → plan, merge → apply. Drift detection Mon–Fri 00:00 UTC via scheduled pipelines.
 - 52 `.tftpl` template files across 10 service workspaces, rendered centrally by `100-pve/config_renderer`.
 - **Recent changes (2026-04-08)**: GitLab Runner (LXC 101) memory increased from 768MB to 3GB (3072MB) for improved Docker-in-Docker CI performance. NFS cache mount enabled at `/srv/gitlab-runner/cache`.
+
+<!-- LLM final probe 1777812678 -->


### PR DESCRIPTION
Final probe after all 3 stages of fixes:
1. GITHUB__USER_TOKEN (dynaconf nested key for github.user_token)
2. OPENAI.KEY (litellm api_key path - was OPENAI_KEY single-underscore)
3. CONFIG.CUSTOM_MODEL_MAX_TOKENS=128000 (kimi/claude not in MAX_TOKENS table)

Expected: github-actions[bot] posts a Korean LLM review comment within ~90s.