### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -39,12 +39,42 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          APPROVER_LOGIN: github-actions[bot]
           DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
           UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
         run: |
-          gh pr review --approve "$PR_URL" \
-            --body "Auto-approved by dependabot-auto-merge ($DEP_NAMES, $UPDATE_TYPE)" \
-          || echo "::warning::approve failed for $PR_URL (already approved or insufficient permissions); continuing"
+          set -euo pipefail
+
+          approval_id="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"$APPROVER_LOGIN\" and .state == \"APPROVED\") | .id" \
+            | tail -n 1)"
+
+          if [[ -n "$approval_id" ]]; then
+            echo "::notice::PR $PR_URL is already approved by $APPROVER_LOGIN (review id: $approval_id); skipping approval"
+            exit 0
+          fi
+
+          if gh pr review --approve "$PR_URL" \
+            --body "Auto-approved by dependabot-auto-merge ($DEP_NAMES, $UPDATE_TYPE)"; then
+            exit 0
+          fi
+
+          status=$?
+          approval_id="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"$APPROVER_LOGIN\" and .state == \"APPROVED\") | .id" \
+            | tail -n 1)"
+
+          if [[ -n "$approval_id" ]]; then
+            echo "::warning::approval command failed, but PR $PR_URL is now approved by $APPROVER_LOGIN (review id: $approval_id); treating as idempotent success"
+            exit 0
+          fi
+
+          echo "::error::failed to approve $PR_URL"
+          exit "$status"
 
       - name: Enable auto-merge for safe updates
         if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.package-ecosystem == 'github_actions' }}
@@ -52,28 +82,117 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          gh pr merge --auto --squash "$PR_URL" \
-          || echo "::warning::auto-merge enable failed for $PR_URL (allow_auto_merge disabled or branch protection missing); continuing"
+          set -euo pipefail
+
+          auto_merge_enabled="$(gh pr view "$PR_URL" \
+            --json autoMergeRequest \
+            --jq '.autoMergeRequest != null')"
+
+          if [[ "$auto_merge_enabled" == "true" ]]; then
+            echo "::notice::auto-merge is already enabled for $PR_URL; skipping"
+            exit 0
+          fi
+
+          if gh pr merge --auto --squash "$PR_URL"; then
+            exit 0
+          fi
+
+          status=$?
+          auto_merge_enabled="$(gh pr view "$PR_URL" \
+            --json autoMergeRequest \
+            --jq '.autoMergeRequest != null')"
+
+          if [[ "$auto_merge_enabled" == "true" ]]; then
+            echo "::warning::auto-merge command failed, but auto-merge is now enabled for $PR_URL; treating as idempotent success"
+            exit 0
+          fi
+
+          echo "::error::failed to enable auto-merge for $PR_URL"
+          exit "$status"
 
       - name: Flag major updates for manual review
         if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' && steps.meta.outputs.package-ecosystem != 'github_actions' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          COMMENT_AUTHOR: github-actions[bot]
           DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
         run: |
-          gh pr comment "$PR_URL" \
-            --body "Major version bump for $DEP_NAMES - manual review required." \
-          || echo "::warning::failed to post manual-review comment for $PR_URL; continuing"
+          set -euo pipefail
+
+          marker="<!-- dependabot-auto-merge:manual-review:major -->"
+          body="$marker"$'\n'"Major version bump for $DEP_NAMES - manual review required."
+
+          comment_id="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"$COMMENT_AUTHOR\" and (.body | contains(\"$marker\"))) | .id" \
+            | tail -n 1)"
+
+          if [[ -n "$comment_id" ]]; then
+            echo "::notice::major-update manual-review comment already exists on $PR_URL (comment id: $comment_id); skipping"
+            exit 0
+          fi
+
+          if gh pr comment "$PR_URL" --body "$body"; then
+            exit 0
+          fi
+
+          status=$?
+          comment_id="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"$COMMENT_AUTHOR\" and (.body | contains(\"$marker\"))) | .id" \
+            | tail -n 1)"
+
+          if [[ -n "$comment_id" ]]; then
+            echo "::warning::comment command failed, but major-update comment now exists on $PR_URL (comment id: $comment_id); treating as idempotent success"
+            exit 0
+          fi
+
+          echo "::error::failed to post major-update manual-review comment for $PR_URL"
+          exit "$status"
 
       - name: Flag unknown update type for manual review
         if: ${{ steps.meta.outputs.update-type == '' || steps.meta.outputs.update-type == 'null' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          COMMENT_AUTHOR: github-actions[bot]
           DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
           ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
         run: |
-          gh pr comment "$PR_URL" \
-            --body "Dependabot did not report a SemVer update-type for $DEP_NAMES (ecosystem=$ECOSYSTEM). Manual review required." \
-          || echo "::warning::failed to post unknown-update-type comment for $PR_URL; continuing"
+          set -euo pipefail
+
+          marker="<!-- dependabot-auto-merge:manual-review:unknown-update-type -->"
+          body="$marker"$'\n'"Dependabot did not report a SemVer update-type for $DEP_NAMES (ecosystem=$ECOSYSTEM). Manual review required."
+
+          comment_id="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"$COMMENT_AUTHOR\" and (.body | contains(\"$marker\"))) | .id" \
+            | tail -n 1)"
+
+          if [[ -n "$comment_id" ]]; then
+            echo "::notice::unknown-update-type manual-review comment already exists on $PR_URL (comment id: $comment_id); skipping"
+            exit 0
+          fi
+
+          if gh pr comment "$PR_URL" --body "$body"; then
+            exit 0
+          fi
+
+          status=$?
+          comment_id="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"$COMMENT_AUTHOR\" and (.body | contains(\"$marker\"))) | .id" \
+            | tail -n 1)"
+
+          if [[ -n "$comment_id" ]]; then
+            echo "::warning::comment command failed, but unknown-update-type comment now exists on $PR_URL (comment id: $comment_id); treating as idempotent success"
+            exit 0
+          fi
+
+          echo "::error::failed to post unknown-update-type manual-review comment for $PR_URL"
+          exit "$status"


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- Dependabot 워크플로우 승인 및 병합 로직 멱등성 개선

- 쉘 스크립트에 `set -euo pipefail` 안전 설정 추가

- major/unknown 업데이트 코멘트 중복 작성 방지

- `gh api`로 기존 상태 확인 후 조건부 처리


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dependabot PR"] --> B["기존 상태 확인"]
  B -- "미처리" --> C["승인/병합/코멘트 실행"]
  B -- "처리됨" --> D["스킵"]
  C --> E["오류 시 재확인 후 완료"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot-auto-merge.yml`</strong><dd><code>Dependabot 자동 병합 워크플로우 멱등성 및 오류 처리 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/dependabot-auto-merge.yml`

<ul><li>PR 승인 전 <code>github-actions[bot]</code>의 기존 승인 여부를 <code>gh api</code>로 확인하여 중복 승인 방지<br> <li> 자동 병합 설정 전 이미 활성화되어 있는지 <code>autoMergeRequest</code> 조회 후 중복 실행 방지<br> <li> major 및 unknown 업데이트 타입의 수동 리뷰 코멘트에 HTML 마커 추가 및 중복 존재 여부 확인<br> <li> 모든 <code>run</code> 블록에 <code>set -euo pipefail</code> 적용과 명령 실패 시 재확인 로직으로 견고성 향상</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

