### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/bot-auto-fix.yml
+++ b/.github/workflows/bot-auto-fix.yml
@@ -1,0 +1,82 @@
+name: Bot Auto-Fix
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '.github/**'
+      - 'scripts/**'
+      - '.ls-lint.yml'
+      - 'docs/**'
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: bot-auto-fix-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-fix:
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref != github.event.repository.default_branch &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.21'
+
+      - name: Run naming validator with --fix
+        id: fix
+        run: |
+          echo "Running validate-naming --fix..."
+          cd scripts
+          go run ./cmd/validate-naming --fix || true
+          echo "Done"
+
+      - name: Check if fixes were applied
+        id: check
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No auto-fixes needed"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Auto-fixes applied"
+            git diff --stat
+          fi
+
+      - name: Push fixes back to PR
+        if: steps.check.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || github.token }}
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+
+          if [ -z "$BRANCH" ] || [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
+            echo "::error::Refusing to push to default branch"
+            exit 1
+          fi
+
+          git config user.email "bot@jclee.me"
+          git config user.name "github-bot"
+          git add -A
+          git commit -m "bot: auto-fix naming conventions [skip ci]"
+          git push origin "HEAD:${BRANCH}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,6 +27,8 @@ jobs:
   dependabot:
     if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false }}
     runs-on: ${{ github.event.repository.private && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -19,5 +19,8 @@ permissions:
 jobs:
   docs-sync:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
+    timeout-minutes: 15
+    uses: jclee941/.github/.github/workflows/reusable-docs-sync.yml@master
+    secrets: inherit
     uses: jclee941/.github/.github/workflows/reusable-docs-sync.yml@master
     secrets: inherit

--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -15,5 +15,8 @@ permissions:
 jobs:
   issue-management:
     if: github.event_name != 'push'
+    timeout-minutes: 15
+    uses: jclee941/.github/.github/workflows/reusable-issue-management.yml@master
+    secrets: inherit
     uses: jclee941/.github/.github/workflows/reusable-issue-management.yml@master
     secrets: inherit


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- Bot Auto-Fix 워크플로우 신규 추가

- 명명 규칙 자동 검사 및 수정 적용

- 기존 자동화 워크플로우 타임아웃 설정 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR opened / synchronized"] --> B["bot-auto-fix.yml"]
  B --> C["validate-naming --fix"]
  C --> D["push fixes to PR"]
  E["existing workflows"] --> F["timeout-minutes added"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bot-auto-fix.yml</strong><dd><code>PR 네이밍 규칙 자동 수정 워크플로우 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/bot-auto-fix.yml

<ul><li><code>.github</code>, <code>scripts</code>, <code>docs</code> 등 지정 경로 변경 시 PR 대상으로 실행<br> <li> Go 기반 <code>validate-naming --fix</code> 명령을 실행해 네이밍 규칙 자동 수정<br> <li> 수정 사항 발생 시 <code>github-bot</code> 계정으로 자동 커밋 및 푸시<br> <li> 기본 브랜치 푸시 방지, Dependabot 제외, 10분 타임아웃 등 안전 장치 적용</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/81/files#diff-83641709b409a398d13e6710839982d35400f566e619bfa0d1c819cf98a3cad3">+82/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot-auto-merge.yml</strong><dd><code>Dependabot 자동 병합 작업 타임아웃 설정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/dependabot-auto-merge.yml

- `dependabot` job에 `timeout-minutes: 10` 추가


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/81/files#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docs-sync.yml</strong><dd><code>문서 동기화 워크플로우 타임아웃 설정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docs-sync.yml

<ul><li><code>docs-sync</code> job에 <code>timeout-minutes: 15</code> 추가<br> <li> <code>jclee941/.github</code> 재사용 워크플로우 호출 구성 유지</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/81/files#diff-f4bfcbba69692fc3c503c6de06be0057b3d1cd35571b3d0e7f14ad12737f217d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>issue-management.yml</strong><dd><code>이슈 관리 워크플로우 타임아웃 설정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/issue-management.yml

<ul><li><code>issue-management</code> job에 <code>timeout-minutes: 15</code> 추가<br> <li> <code>jclee941/.github</code> 재사용 워크플로우 호출 구성 유지</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/81/files#diff-622305f818c39f35da0f77dc95215ed18be48e81afc57f291e140ed77b0a8f93">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

