### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -16,6 +16,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: docs-sync-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docs-sync:
     if: github.event_name == 'push' || github.event_name == 'pull_request'

--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -12,6 +12,10 @@ permissions:
   issues: write
   contents: read
 
+concurrency:
+  group: issue-management
+  cancel-in-progress: false
+
 jobs:
   issue-management:
     if: github.event_name != 'push'

--- a/.github/workflows/reusable-docs-sync.yml
+++ b/.github/workflows/reusable-docs-sync.yml
@@ -8,6 +8,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: reusable-docs-sync-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   link-check:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/reusable-issue-management.yml
+++ b/.github/workflows/reusable-issue-management.yml
@@ -7,6 +7,10 @@ permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: reusable-issue-management-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   stale-check:
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}

--- a/.github/workflows/reusable-pr-checks.yml
+++ b/.github/workflows/reusable-pr-checks.yml
@@ -8,6 +8,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: reusable-pr-checks-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-size:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- 5개 GitHub Actions 워크플로우에 `concurrency` 설정 추가

- 중복 실행 방지 및 불필요한 리소스 절약

- `issue-management` 워크플로우는 진행 중 실행 유지

- 나머지 워크플로우는 새 실행 시 기존 실행 취소


___

### Diagram Walkthrough


```mermaid
flowchart LR
  workflows["5개 워크플로우"] --> config["concurrency 설정 추가"]
  config --> behavior["동시 실행 제어"]
  behavior --> true["cancel-in-progress: true"]
  behavior --> false["cancel-in-progress: false"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docs-sync.yml</strong><dd><code>docs-sync 워크플로우에 concurrency 설정 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docs-sync.yml

<ul><li><code>concurrency</code> 블록 추가<br> <li> <code>group: docs-sync-${{ github.ref }}</code> 및 <code>cancel-in-progress: true</code> 설정</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/84/files#diff-f4bfcbba69692fc3c503c6de06be0057b3d1cd35571b3d0e7f14ad12737f217d">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>issue-management.yml</strong><dd><code>issue-management 워크플로우에 concurrency 설정 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/issue-management.yml

<ul><li><code>concurrency</code> 블록 추가<br> <li> <code>group: issue-management</code> 및 <code>cancel-in-progress: false</code> 설정</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/84/files#diff-622305f818c39f35da0f77dc95215ed18be48e81afc57f291e140ed77b0a8f93">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reusable-docs-sync.yml</strong><dd><code>reusable-docs-sync 워크플로우에 concurrency 설정 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-docs-sync.yml

<ul><li><code>concurrency</code> 블록 추가<br> <li> <code>group: reusable-docs-sync-${{ github.ref }}</code> 및 <code>cancel-in-progress: true</code> <br>설정</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/84/files#diff-4a1f29f72a980db95bc8265ef1c75404098d95a138d2c59772083ec5259c4d2a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reusable-issue-management.yml</strong><dd><code>reusable-issue-management 워크플로우에 concurrency 설정 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-issue-management.yml

<ul><li><code>concurrency</code> 블록 추가<br> <li> <code>group: reusable-issue-management-${{ github.ref }}</code> 및 <br><code>cancel-in-progress: true</code> 설정</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/84/files#diff-321d5a584f7c9be882556476d570355f5243ec98cb2925e63566ada047783335">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reusable-pr-checks.yml</strong><dd><code>reusable-pr-checks 워크플로우에 concurrency 설정 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-pr-checks.yml

<ul><li><code>concurrency</code> 블록 추가<br> <li> <code>group: reusable-pr-checks-${{ github.ref }}</code> 및 <code>cancel-in-progress: true</code> <br>설정</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/84/files#diff-c847d70b033c8a55778bee6b336f27519c76efbe8d9f7b8c67108ef006d42ee7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

