### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/20_readme-gen.yml
+++ b/.github/workflows/20_readme-gen.yml
@@ -109,6 +109,11 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         run: |
           set -eu
+          # Resolve the repo default branch for the PR base. GITHUB_REF_NAME can be
+          # a ref path on some events and is wrong for downstream repos that use
+          # `main`; the default branch is always a valid base.
+          base_branch=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)
+          base_branch=${base_branch:-${GITHUB_REF_NAME:-master}}
           existing=$(gh pr list --head bot/auto-readme-update --json number --jq '.[0].number')
           if [ -n "$existing" ]; then
             gh pr edit "$existing" --title "docs: auto-update README.md" --body "Automated README.md update by jclee-bot."
@@ -116,7 +121,7 @@ jobs:
             gh pr create \
               --title "docs: auto-update README.md" \
               --body "Automated README.md update by jclee-bot." \
-              --base "${GITHUB_REF_NAME}" \
+              --base "$base_branch" \
               --head bot/auto-readme-update
           fi
         env:


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- `gh repo view`로 기본 브랜치 동적 조회

- `GITHUB_REF_NAME` 하드코딩 제거

- 다운스트림 저장소 기본 브랜치 호환 개선


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>20_readme-gen.yml</strong><dd><code>README 워크플로우 PR 베이스 브랜치 버그 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/20_readme-gen.yml

<ul><li><code>gh repo view --json defaultBranchRef</code> 명령으로 저장소 기본 브랜치를 동적으로 조회<br> <li> <code>GITHUB_REF_NAME</code> 대신 조회된 기본 브랜치를 PR <code>--base</code> 인자로 사용<br> <li> 다운스트림 저장소의 기본 브랜치가 <code>main</code> 등일 때도 정상 작동하도록 수정</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/192/files#diff-3151312623e64c1035ee16621695ce8cf19800d6f70cb01f238c4d309d518c5a">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

