### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/scripts/issue-classifier.js
+++ b/.github/scripts/issue-classifier.js
@@ -1,0 +1,455 @@
+// issue-classifier.js — deterministic, dependency-free issue classification.
+//
+// Why this exists
+// ---------------
+// `.github/workflows/91_issue-classification.yml` runs this module inside
+// `actions/github-script@v9` to decide how to handle GitHub issues:
+//   * duplicate detection  — compare a new issue against existing open issues
+//                            with a token-Jaccard similarity (no embeddings,
+//                            no vector DB, no network — must run offline in CI).
+//   * resolved detection   — issues closed-by a merged PR (Closes/Fixes/Resolves
+//                            keyword or `issue-N` branch), or issues whose text
+//                            carries an explicit "fixed/resolved" signal.
+//
+// This module is PURE: it never calls the GitHub API. It only computes a plan
+// (which labels to add, what comment to post, whether to close). The workflow
+// performs the side effects. That keeps the logic unit-testable via Node
+// (see scripts/issue_classifier_js_test.py) without mocking the API.
+//
+// All comments emitted carry a stable HTML marker so the workflow can avoid
+// posting duplicates on re-runs / edits.
+
+'use strict';
+
+// Markers let the workflow find its own previous comments and stay idempotent.
+const DUP_MARKER = '<!-- issue-classification:duplicate -->';
+const RESOLVED_MARKER = '<!-- issue-classification:resolved -->';
+
+// Default thresholds / toggles. Conservative by design: we never auto-close a
+// duplicate, and we only auto-close resolved issues when a merged PR explicitly
+// references them. Everything is overridable via config (workflow inputs/env).
+const DEFAULT_CONFIG = {
+  duplicateThreshold: 0.58,        // min score to flag as a possible duplicate
+  duplicateCloseThreshold: 0.86,   // min score required before a close is allowed
+  closeDuplicates: false,          // auto-close duplicates at all
+  maxDuplicateMatches: 3,          // cap links posted in the comment
+  closeResolvedByPr: true,         // close issues a merged PR says it resolves
+  closeResolvedBySignal: false,    // close issues with only a text "fixed" signal
+  maxCandidates: 100,              // cap candidates scanned for duplicates
+  dryRun: false,                   // compute the plan but mark it a no-op
+};
+
+// Stopwords are dropped before similarity so boilerplate ("the", "a", "to")
+// does not inflate the overlap between unrelated issues.
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'with', 'is',
+  'are', 'was', 'were', 'be', 'been', 'this', 'that', 'it', 'as', 'at', 'by',
+  'from', 'i', 'we', 'you', 'my', 'me', 'so', 'if', 'no', 'not', 'do', 'does',
+  'did', 'has', 'have', 'had', 'but', 'when', 'then', 'there', 'here', 'out',
+  'up', 'about', 'into', 'over', 'after', 'before', 'please', 'would', 'could',
+  'should', 'can', 'will', 'just', 'also', 'any', 'all', 'some', 'more',
+]);
+
+// Closing keywords GitHub itself honours, plus our `issue-N` branch convention.
+const CLOSING_KEYWORDS = [
+  'close', 'closes', 'closed',
+  'fix', 'fixes', 'fixed',
+  'resolve', 'resolves', 'resolved',
+];
+
+// Phrases that signal an issue is effectively resolved. Deliberately specific
+// to avoid false positives — a lone "done" or "fix" must NOT trigger this.
+const RESOLVED_SIGNALS = [
+  'this is now fixed',
+  'now fixed',
+  'is fixed',
+  'has been fixed',
+  'no longer reproduces',
+  'no longer reproducible',
+  'no longer an issue',
+  'works now',
+  'is resolved',
+  'has been resolved',
+  'now resolved',
+  // Note: concrete "fixed/resolved in v2 | #123 | release | version | pr | commit"
+  // references are matched by a regex in hasResolvedSignal(), NOT by broad
+  // phrases here — a bare "resolved in" would false-match "resolved in v2?".
+];
+
+// Phrases that explicitly negate a resolved signal ("not resolved", "still
+// happening"). If any are present we never flag the issue as resolved.
+const NEGATIONS = [
+  'not fixed',
+  'not resolved',
+  'still happening',
+  'still occurs',
+  'still reproduces',
+  'still get',
+  'still getting',
+  'still broken',
+  'is not resolved',
+  "isn't fixed",
+  "isn't resolved",
+  'unresolved',
+  'should be fixed',
+  'needs to be fixed',
+  'to be fixed',
+  'be fixed in',
+  'can this be fixed',
+  'will be fixed',
+  'fixed in a future',
+  'fixed in future',
+  'should be resolved',
+  'needs to be resolved',
+  'to be resolved',
+  'be resolved in',
+  'can this be resolved',
+  'will be resolved',
+  'resolved in a future',
+  'resolved in future',
+];
+
+function normalizeText(text) {
+  if (text === null || text === undefined) return '';
+  let s = String(text).toLowerCase();
+  s = s.replace(/```[\s\S]*?```/g, ' ');   // drop fenced code blocks
+  s = s.replace(/`[^`]*`/g, ' ');          // drop inline code
+  s = s.replace(/https?:\/\/\S+/g, ' ');   // drop URLs
+  s = s.replace(/[^a-z0-9\s]/g, ' ');      // punctuation -> space
+  s = s.replace(/\s+/g, ' ').trim();
+  return s;
+}
+
+function tokenize(text) {
+  const norm = normalizeText(text);
+  if (!norm) return new Set();
+  const out = new Set();
+  for (const tok of norm.split(' ')) {
+    if (tok.length < 2) continue;          // single chars carry no signal
+    if (STOPWORDS.has(tok)) continue;
+    out.add(tok);
+  }
+  return out;
+}
+
+function jaccardSimilarity(aTokens, bTokens) {
+  const a = aTokens instanceof Set ? aTokens : new Set(aTokens);
+  const b = bTokens instanceof Set ? bTokens : new Set(bTokens);
+  if (a.size === 0 && b.size === 0) return 0;
+  let inter = 0;
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+  for (const t of small) if (large.has(t)) inter += 1;
+  const union = a.size + b.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+// Combine title and body similarity. Titles are weighted more heavily because
+// they are the most reliable signal of "same problem".
+function scoreIssueSimilarity(target, candidate) {
+  const titleScore = jaccardSimilarity(
+    tokenize(target.title),
+    tokenize(candidate.title),
+  );
+  const bodyScore = jaccardSimilarity(
+    tokenize(target.body),
+    tokenize(candidate.body),
+  );
+  return 0.65 * titleScore + 0.35 * bodyScore;
+}
+
+function isPullRequest(issue) {
+  // GitHub's issues API returns PRs too; they carry a `pull_request` key.
+  return Boolean(issue && issue.pull_request);
+}
+
+function isOpen(issue) {
+  // Treat a missing state as open (issue payloads on `opened` omit nothing,
+  // but list responses always include it).
+  return !issue || issue.state === undefined || issue.state === 'open';
+}
+
+// Minimum corroborating evidence before a pair may be called a duplicate.
+// Guards against generic titles ("Build failed", "Crash") matching on the title
+// alone with unrelated bodies. Requires EITHER body overlap, OR a strong title
+// match backed by several shared meaningful tokens.
+function hasDuplicateEvidence(target, candidate) {
+  const tTitle = tokenize(target.title);
+  const cTitle = tokenize(candidate.title);
+  const titleScore = jaccardSimilarity(tTitle, cTitle);
+  const bodyScore = jaccardSimilarity(tokenize(target.body), tokenize(candidate.body));
+  let titleInter = 0;
+  for (const t of tTitle) if (cTitle.has(t)) titleInter += 1;
+  // Body corroborates similarity — trust it.
+  if (bodyScore >= 0.2) return true;
+  // Title-only match: require a strong title overlap AND at least minimal body
+  // corroboration (bodyScore > 0), OR a long shared-title signal (>= 5 tokens).
+  // This blocks short exact generic titles ("build failed again") whose bodies
+  // share nothing, while still catching genuinely-similar issues.
+  if (titleScore >= 0.6 && titleInter >= 3 && bodyScore > 0) return true;
+  return titleScore >= 0.6 && titleInter >= 5;
+}
+
+// Rank existing issues by similarity to `target`. Skips PRs, closed issues, and
+// the target itself. Returns up to `maxDuplicateMatches` entries above threshold.
+function findDuplicateCandidates(target, candidates, config = DEFAULT_CONFIG) {
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+  const scored = [];
+  let scanned = 0;
+  for (const cand of candidates || []) {
+    if (isPullRequest(cand)) continue;
+    if (!isOpen(cand)) continue;
+    if (cand.number === target.number) continue;
+    if (scanned >= cfg.maxCandidates) break;
+    scanned += 1;
+    const score = scoreIssueSimilarity(target, cand);
+    if (score >= cfg.duplicateThreshold && hasDuplicateEvidence(target, cand)) {
+      scored.push({ number: cand.number, title: cand.title, score: round2(score) });
+    }
+  }
+  scored.sort((x, y) => (y.score - x.score) || (x.number - y.number));
+  return scored.slice(0, cfg.maxDuplicateMatches);
+}
+
+// Build the duplicate-classification plan (no side effects).
+function classifyDuplicate(target, candidates, config = DEFAULT_CONFIG) {
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+  const matches = findDuplicateCandidates(target, candidates, cfg);
+  if (matches.length === 0) {
+    return { matches: [], label: null, comment: null, shouldClose: false, dryRun: cfg.dryRun };
+  }
+  const top = matches[0];
+  const shouldClose =
+    !cfg.dryRun && cfg.closeDuplicates && top.score >= cfg.duplicateCloseThreshold;
+  return {
+    matches,
+    label: 'duplicate',
+    comment: buildDuplicateComment(matches, cfg),
+    shouldClose,
+    dryRun: cfg.dryRun,
+  };
+}
+
+// Pull issue numbers a PR closes: keyword references in title/body plus the
+// `issue-N` branch convention. De-duplicated, sorted ascending.
+function extractLinkedIssueNumbers(text, branchName) {
+  const found = new Set();
+  const haystack = String(text || '');
+  const kw = CLOSING_KEYWORDS.join('|');
+  const re = new RegExp(`\\b(?:${kw})\\b[:\\s]+#(\\d+)`, 'gi');
+  let m;
+  while ((m = re.exec(haystack)) !== null) {
+    found.add(parseInt(m[1], 10));
+  }
+  if (branchName) {
+    const bm = String(branchName).match(/issue[-_/]?(\d+)/i);
+    if (bm) found.add(parseInt(bm[1], 10));
+  }
+  return [...found].sort((a, b) => a - b);
+}
+
+function containsAny(haystack, phrases) {
+  const norm = normalizeText(haystack);
+  return phrases.some((p) => norm.includes(normalizeText(p)));
+}
+
+// Detect an explicit "this is resolved" signal in an issue/comment, guarding
+// against negations so "still not fixed" never counts as resolved.
+function hasResolvedSignal(issueOrComment) {
+  const text = `${issueOrComment.title || ''} ${issueOrComment.body || ''}`;
+  if (containsAny(text, NEGATIONS)) return false;
+  if (containsAny(text, RESOLVED_SIGNALS)) return true;
+  // "fixed in v2", "fixed in #123", "resolved in 1.2.0", "fixed in release 3"
+  // — a *concrete* fix reference, not a future-tense ask. normalizeText strips
+  // the '#'/'.', so match against the raw lowercased text instead.
+  const raw = String(text).toLowerCase();
+  return /\b(?:fixed|resolved)\s+in\s+(?:#?\d|v\d|release\b|version\b|pr\b|commit\b)/.test(raw);
+}
+
+// Plan for a merged PR that references issues.
+function classifyResolvedByPr(pr, config = DEFAULT_CONFIG) {
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+  const branch = (pr.head && pr.head.ref) || pr.headRefName || '';
+  const issueNumbers = extractLinkedIssueNumbers(
+    `${pr.title || ''}\n${pr.body || ''}`,
+    branch,
+  );
+  if (issueNumbers.length === 0) {
+    return { issueNumbers: [], label: null, comment: null, shouldClose: false, dryRun: cfg.dryRun };
+  }
+  return {
+    issueNumbers,
+    label: 'resolved',
+    comment: buildResolvedComment(`merged pull request #${pr.number}`),
+    shouldClose: !cfg.dryRun && cfg.closeResolvedByPr,
+    dryRun: cfg.dryRun,
+  };
+}
+
+// Plan for an issue/comment carrying a text resolved-signal.
+function classifyResolvedBySignal(issue, config = DEFAULT_CONFIG) {
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+  if (!hasResolvedSignal(issue)) {
+    return { label: null, comment: null, shouldClose: false, dryRun: cfg.dryRun };
+  }
+  return {
+    label: 'resolved',
+    comment: buildResolvedComment('an explicit resolved/fixed signal in the issue thread'),
+    shouldClose: !cfg.dryRun && cfg.closeResolvedBySignal,
+    dryRun: cfg.dryRun,
+  };
+}
+
+function buildDuplicateComment(matches, config = DEFAULT_CONFIG) {
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+  const links = matches
+    .slice(0, cfg.maxDuplicateMatches)
+    .map((m) => `- #${m.number} (similarity ${m.score})`)
+    .join('\n');
+  const lead = matches.length === 1
+    ? `This issue looks like a possible duplicate of #${matches[0].number}.`
+    : 'This issue looks like a possible duplicate of:';
+  return (
+    `${DUP_MARKER}\n` +
+    `🔁 **Possible duplicate detected**\n\n` +
+    `${lead}\n\n${links}\n\n` +
+    `If this is *not* a duplicate, remove the \`duplicate\` label. ` +
+    `Auto-classified by the issue-classification workflow.`
+  );
+}
+
+function buildResolvedComment(reason) {
+  return (
+    `${RESOLVED_MARKER}\n` +
+    `✅ **Marked as resolved**\n\n` +
+    `This issue appears to be resolved by ${reason}. ` +
+    `If it is still occurring, reopen it or remove the \`resolved\` label. ` +
+    `Auto-classified by the issue-classification workflow.`
+  );
+}
+
+// Parse a flat config object (env-style strings or workflow inputs) into a
+// typed config. Unknown keys are ignored; unset keys fall back to defaults.
+function parseConfig(raw = {}) {
+  const cfg = { ...DEFAULT_CONFIG };
+  const numKeys = {
+    duplicate_threshold: 'duplicateThreshold',
+    duplicate_close_threshold: 'duplicateCloseThreshold',
+    max_duplicate_matches: 'maxDuplicateMatches',
+    max_candidates: 'maxCandidates',
+  };
+  const boolKeys = {
+    close_duplicates: 'closeDuplicates',
+    close_resolved_by_pr: 'closeResolvedByPr',
+    close_resolved_by_signal: 'closeResolvedBySignal',
+    dry_run: 'dryRun',
+  };
+  for (const [k, target] of Object.entries(numKeys)) {
+    if (raw[k] !== undefined && raw[k] !== null && raw[k] !== '') {
+      const v = Number(raw[k]);
+      if (!Number.isNaN(v)) cfg[target] = v;
+    }
+  }
+  for (const [k, target] of Object.entries(boolKeys)) {
+    if (raw[k] !== undefined && raw[k] !== null && raw[k] !== '') {
+      cfg[target] = toBool(raw[k]);
+    }
+  }
+  return cfg;
+}
+
+function toBool(v) {
+  if (typeof v === 'boolean') return v;
+  return ['true', '1', 'yes', 'on'].includes(String(v).toLowerCase());
+}
+
+function round2(n) {
+  return Math.round(n * 100) / 100;
+}
+
+module.exports = {
+  DUP_MARKER,
+  RESOLVED_MARKER,
+  DEFAULT_CONFIG,
+  normalizeText,
+  tokenize,
+  jaccardSimilarity,
+  scoreIssueSimilarity,
+  findDuplicateCandidates,
+  classifyDuplicate,
+  extractLinkedIssueNumbers,
+  hasResolvedSignal,
+  classifyResolvedByPr,
+  classifyResolvedBySignal,
+  buildDuplicateComment,
+  buildResolvedComment,
+  parseConfig,
+};
+
+// ---------------------------------------------------------------------------
+// CLI mode — local QA + pytest harness. Reads JSON fixtures, prints a JSON plan.
+//   node issue-classifier.js --mode duplicate --issue X.json --candidates Y.json
+//   node issue-classifier.js --mode resolved-pr --pr P.json
+//   node issue-classifier.js --mode resolved-signal --issue I.json
+// ---------------------------------------------------------------------------
+function parseArgv(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        args[key] = 'true';
+      } else {
+        args[key] = next;
+        i += 1;
+      }
+    }
+  }
+  return args;
+}
+
+function readJson(path) {
+  const fs = require('fs');
+  return JSON.parse(fs.readFileSync(path, 'utf8'));
+}
+
+function cliConfig(args) {
+  return parseConfig({
+    duplicate_threshold: args['duplicate-threshold'],
+    duplicate_close_threshold: args['duplicate-close-threshold'],
+    max_duplicate_matches: args['max-duplicate-matches'],
+    max_candidates: args['max-candidates'],
+    close_duplicates: args['close-duplicates'],
+    close_resolved_by_pr: args['close-resolved-by-pr'],
+    close_resolved_by_signal: args['close-resolved-by-signal'],
+    dry_run: args['dry-run'],
+  });
+}
+
+function runCli(argv) {
+  const args = parseArgv(argv);
+  const mode = args.mode;
+  const cfg = cliConfig(args);
+  let result;
+  if (mode === 'duplicate') {
+    const issue = readJson(args.issue);
+    const candidates = readJson(args.candidates);
+    result = classifyDuplicate(issue, candidates, cfg);
+  } else if (mode === 'resolved-pr') {
+    const pr = readJson(args.pr);
+    result = classifyResolvedByPr(pr, cfg);
+  } else if (mode === 'resolved-signal') {
+    const issue = readJson(args.issue);
+    result = classifyResolvedBySignal(issue, cfg);
+  } else {
+    process.stderr.write(`unknown --mode: ${mode}\n`);
+    process.exit(2);
+    return;
+  }
+  process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+}
+
+if (require.main === module) {
+  runCli(process.argv.slice(2));
+}

--- a/.github/workflows/91_issue-classification.yml
+++ b/.github/workflows/91_issue-classification.yml
@@ -1,0 +1,544 @@
+name: Issue Classification
+
+# Auto-classify and process issues:
+#   * duplicate-classification  — on new/edited issues, find similar OPEN issues
+#                                 (token-Jaccard, no embeddings), label `duplicate`,
+#                                 comment with likely originals. Never auto-closes
+#                                 unless explicitly enabled with a high threshold.
+#   * resolved-from-merged-pr   — when a PR merges, label+close the issues it
+#                                 Closes/Fixes/Resolves (or `issue-N` branch).
+#   * resolved-from-signal      — on edits/comments carrying an explicit
+#                                 "fixed/resolved" signal, label `resolved`
+#                                 (close only when opted in).
+#   * resolved-sweep            — scheduled sweep: open issues whose linked PR is
+#                                 already merged get labeled/closed.
+#
+# All pure logic lives in `.github/scripts/issue-classifier.js` (unit-tested via
+# scripts/issue_classifier_js_test.py and node --check in 90_sanity.yml). This
+# workflow only performs the GitHub-side effects. `dry_run` logs the plan
+# without mutating anything.
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [closed]
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Log planned actions without mutating issues
+        required: false
+        type: boolean
+        default: false
+      duplicate_threshold:
+        description: Min similarity (0-1) to flag a duplicate
+        required: false
+        type: string
+        default: '0.58'
+      duplicate_close_threshold:
+        description: Min similarity (0-1) required before a duplicate may be closed
+        required: false
+        type: string
+        default: '0.86'
+      close_duplicates:
+        description: Auto-close high-confidence duplicates
+        required: false
+        type: boolean
+        default: false
+      close_resolved_by_pr:
+        description: Auto-close issues referenced by a merged PR
+        required: false
+        type: boolean
+        default: true
+      close_resolved_by_signal:
+        description: Auto-close issues with only a text resolved signal
+        required: false
+        type: boolean
+        default: false
+      max_candidates:
+        description: Max open issues scanned for duplicate detection
+        required: false
+        type: string
+        default: '100'
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: issue-classification-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+env:
+  DRY_RUN: ${{ inputs.dry_run || 'false' }}
+  DUPLICATE_THRESHOLD: ${{ inputs.duplicate_threshold || '0.58' }}
+  DUPLICATE_CLOSE_THRESHOLD: ${{ inputs.duplicate_close_threshold || '0.86' }}
+  CLOSE_DUPLICATES: ${{ inputs.close_duplicates || 'false' }}
+  # Default ON. Only a workflow_dispatch run that explicitly sets the input to
+  # false may disable it; on issues/PR/schedule events `inputs` is absent and we
+  # must NOT let empty-string coerce to false.
+  CLOSE_RESOLVED_BY_PR: ${{ github.event_name == 'workflow_dispatch' && inputs.close_resolved_by_pr == false && 'false' || 'true' }}
+  CLOSE_RESOLVED_BY_SIGNAL: ${{ inputs.close_resolved_by_signal || 'false' }}
+  MAX_CANDIDATES: ${{ inputs.max_candidates || '100' }}
+
+jobs:
+  duplicate-classification:
+    name: Duplicate detection
+    if: github.event_name == 'issues' && contains(fromJson('["opened", "edited", "reopened"]'), github.event.action)
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Classify duplicate issue
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const path = require('path');
+            const classifier = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/issue-classifier.js'));
+            // Ensure a label exists before adding it (avoids a 404 on repos that
+            // lack the label).
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+                try {
+                  await github.rest.issues.createLabel({ owner: context.repo.owner, repo: context.repo.repo, name, color, description });
+                } catch (ce) {
+                  if (ce.status !== 422) throw ce;
+                }
+              }
+            }
+            const cfg = classifier.parseConfig({
+              duplicate_threshold: process.env.DUPLICATE_THRESHOLD,
+              duplicate_close_threshold: process.env.DUPLICATE_CLOSE_THRESHOLD,
+              close_duplicates: process.env.CLOSE_DUPLICATES,
+              max_candidates: process.env.MAX_CANDIDATES,
+              dry_run: process.env.DRY_RUN,
+            });
+
+            const issue = context.payload.issue;
+            if (!issue || issue.pull_request) {
+              core.info('Not an issue payload; skipping.');
+              return;
+            }
+
+            const candidates = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const plan = classifier.classifyDuplicate(issue, candidates, cfg);
+            if (plan.matches.length === 0) {
+              core.info(`#${issue.number}: no duplicate candidates above threshold.`);
+              return;
+            }
+            core.info(`#${issue.number}: duplicate plan -> ${JSON.stringify(plan.matches)} (dryRun=${plan.dryRun})`);
+
+            if (plan.dryRun) {
+              core.notice(`[dry-run] would label #${issue.number} duplicate and comment.`);
+              return;
+            }
+
+            await ensureLabel('duplicate', 'cfd3d7', 'Auto-classified: possible duplicate');
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ['duplicate'],
+            });
+
+            // Idempotency: do not repeat the duplicate comment on edits.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              per_page: 100,
+            });
+            const already = comments.some(c => c.body && c.body.includes(classifier.DUP_MARKER));
+            if (!already) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: plan.comment,
+              });
+            }
+
+            if (plan.shouldClose) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned',
+              });
+              core.notice(`Closed #${issue.number} as a high-confidence duplicate.`);
+            }
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-on-failure
+
+  resolved-from-merged-pr:
+    name: Resolved by merged PR
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Resolve issues linked to the merged PR
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const path = require('path');
+            const classifier = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/issue-classifier.js'));
+            const cfg = classifier.parseConfig({
+              close_resolved_by_pr: process.env.CLOSE_RESOLVED_BY_PR,
+              dry_run: process.env.DRY_RUN,
+            });
+
+            // Ensure a label exists before adding it; `resolved` is not a default
+            // GitHub label, so addLabels would otherwise 404.
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+                try {
+                  await github.rest.issues.createLabel({ owner: context.repo.owner, repo: context.repo.repo, name, color, description });
+                } catch (ce) {
+                  if (ce.status !== 422) throw ce;  // 422 = already created by a race
+                }
+              }
+            }
+
+            const pr = context.payload.pull_request;
+            const plan = classifier.classifyResolvedByPr({
+              number: pr.number,
+              title: pr.title,
+              body: pr.body,
+              head: { ref: pr.head && pr.head.ref },
+            }, cfg);
+
+            if (plan.issueNumbers.length === 0) {
+              core.info(`PR #${pr.number}: no linked issues to resolve.`);
+              return;
+            }
+            core.info(`PR #${pr.number}: resolving ${JSON.stringify(plan.issueNumbers)} (close=${plan.shouldClose}, dryRun=${plan.dryRun})`);
+
+            for (const num of plan.issueNumbers) {
+              try {
+                const { data: target } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                });
+                if (target.pull_request) continue;          // skip PRs (not issues)
+                const alreadyClosed = target.state === 'closed';
+                // Note: GitHub auto-closes issues for Closes/Fixes/Resolves #N on
+                // merge, so the issue may ALREADY be closed here. We still want to
+                // label + comment it (classification), and only skip the close call.
+
+                if (plan.dryRun) {
+                  core.notice(`[dry-run] would resolve #${num} via PR #${pr.number} (alreadyClosed=${alreadyClosed}).`);
+                  continue;
+                }
+
+                await ensureLabel('resolved', '0e8a16', 'Auto-classified: issue resolved');
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                  labels: ['resolved'],
+                });
+
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                  per_page: 100,
+                });
+                const already = comments.some(c => c.body && c.body.includes(classifier.RESOLVED_MARKER));
+                if (!already) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: num,
+                    body: plan.comment,
+                  });
+                }
+
+                if (plan.shouldClose && !alreadyClosed) {
+                  await github.rest.issues.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: num,
+                    state: 'closed',
+                    state_reason: 'completed',
+                  });
+                  core.notice(`Closed #${num} (resolved by merged PR #${pr.number}).`);
+                }
+              } catch (e) {
+                core.warning(`Failed to process issue #${num}: ${e.message}`);
+              }
+            }
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-on-failure
+
+  resolved-from-signal:
+    name: Resolved by text signal
+    if: (github.event_name == 'issues' && contains(fromJson('["edited", "reopened"]'), github.event.action)) || (github.event_name == 'issue_comment' && github.event.action == 'created')
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Detect resolved signal
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const path = require('path');
+            const classifier = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/issue-classifier.js'));
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+                try {
+                  await github.rest.issues.createLabel({ owner: context.repo.owner, repo: context.repo.repo, name, color, description });
+                } catch (ce) {
+                  if (ce.status !== 422) throw ce;
+                }
+              }
+            }
+            const cfg = classifier.parseConfig({
+              close_resolved_by_signal: process.env.CLOSE_RESOLVED_BY_SIGNAL,
+              dry_run: process.env.DRY_RUN,
+            });
+
+            const issue = context.payload.issue;
+            if (!issue || issue.pull_request) {
+              core.info('Not an issue payload; skipping.');
+              return;
+            }
+            if (issue.state === 'closed') {
+              core.info(`#${issue.number} already closed; skipping.`);
+              return;
+            }
+
+            // Consider the issue body plus the triggering comment (if any).
+            const commentBody = (context.payload.comment && context.payload.comment.body) || '';
+            const subject = {
+              title: issue.title,
+              body: `${issue.body || ''}\n${commentBody}`,
+            };
+
+            const plan = classifier.classifyResolvedBySignal(subject, cfg);
+            if (!plan.label) {
+              core.info(`#${issue.number}: no resolved signal detected.`);
+              return;
+            }
+            core.info(`#${issue.number}: resolved-signal plan (close=${plan.shouldClose}, dryRun=${plan.dryRun}).`);
+
+            if (plan.dryRun) {
+              core.notice(`[dry-run] would mark #${issue.number} resolved.`);
+              return;
+            }
+
+            await ensureLabel('resolved', '0e8a16', 'Auto-classified: issue resolved');
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ['resolved'],
+            });
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              per_page: 100,
+            });
+            const already = comments.some(c => c.body && c.body.includes(classifier.RESOLVED_MARKER));
+            if (!already) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: plan.comment,
+              });
+            }
+
+            if (plan.shouldClose) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              core.notice(`Closed #${issue.number} (resolved signal).`);
+            }
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-on-failure
+
+  resolved-sweep:
+    name: Scheduled resolved sweep
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Sweep open issues linked to merged PRs
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const path = require('path');
+            const classifier = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/issue-classifier.js'));
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+                try {
+                  await github.rest.issues.createLabel({ owner: context.repo.owner, repo: context.repo.repo, name, color, description });
+                } catch (ce) {
+                  if (ce.status !== 422) throw ce;
+                }
+              }
+            }
+            const cfg = classifier.parseConfig({
+              close_resolved_by_pr: process.env.CLOSE_RESOLVED_BY_PR,
+              dry_run: process.env.DRY_RUN,
+            });
+
+            // Walk recently-merged PRs and resolve any still-open linked issues.
+            // Bound the scan to a recent window (~150 PRs) so the sweep stays cheap.
+            const prsPages = [];
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 50,
+            }, (response, done) => {
+              prsPages.push(response.data.length);
+              if (prsPages.length >= 3) {
+                done();
+              }
+              return response.data;
+            });
+
+            let processed = 0;
+            for (const pr of prs) {
+              if (!pr.merged_at) continue;
+              if (processed >= 150) break;
+              processed += 1;
+
+              const plan = classifier.classifyResolvedByPr({
+                number: pr.number,
+                title: pr.title,
+                body: pr.body,
+                head: { ref: pr.head && pr.head.ref },
+              }, cfg);
+              if (plan.issueNumbers.length === 0) continue;
+
+              for (const num of plan.issueNumbers) {
+                try {
+                  const { data: target } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: num,
+                  });
+                  if (target.pull_request) continue;
+                  if (target.state === 'closed') continue;
+
+                  if (plan.dryRun) {
+                    core.notice(`[dry-run] sweep would resolve #${num} via PR #${pr.number}.`);
+                    continue;
+                  }
+
+                  await ensureLabel('resolved', '0e8a16', 'Auto-classified: issue resolved');
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: num,
+                    labels: ['resolved'],
+                  });
+
+                  const comments = await github.paginate(github.rest.issues.listComments, {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: num,
+                    per_page: 100,
+                  });
+                  const already = comments.some(c => c.body && c.body.includes(classifier.RESOLVED_MARKER));
+                  if (!already) {
+                    await github.rest.issues.createComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: num,
+                      body: plan.comment,
+                    });
+                  }
+
+                  if (plan.shouldClose) {
+                    await github.rest.issues.update({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: num,
+                      state: 'closed',
+                      state_reason: 'completed',
+                    });
+                    core.notice(`Sweep closed #${num} (resolved by merged PR #${pr.number}).`);
+                  }
+                } catch (e) {
+                  core.warning(`Sweep failed for issue #${num}: ${e.message}`);
+                }
+              }
+            }
+            core.info(`Sweep scanned ${processed} merged PR(s).`);
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-on-failure


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
enhancement


___

### **Description**
- GitHub 이슈 자동 분류 시스템 추가 (의존성 없는 Jaccard 유사도 기반)

- 중복 이슈 감지: 제목(65%) + 본문(35%) 토큰 유사도로 유사 이슈 연결

- 병합된 PR로 해결됨 감지: Closes/Fixes/Resolves 키워드 및 issue-N 브랜치 규칙

- 텍스트 신호 기반 해결 감지: "fixed", "resolved" 등 명시적 표현 탐지

- 4개 워크플로우 잡: 중복 분류, PR 병합 해결, 신호 해결, 스케줄 스위프


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Issue 열림/편집] --> B[duplicate-classification]
  C[PR 병합] --> D[resolved-from-merged-pr]
  E[이슈 편집/코멘트] --> F[resolved-from-signal]
  G[스케줄] --> H[resolved-sweep]
  B --> I["duplicate 라벨 추가"]
  D --> J["resolved 라벨 추가 + 닫기"]
  F --> J
  H --> J
  I --> K[유사 이슈 링크 코멘트]
  J --> L[해결 코멘트]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issue-classifier.js</strong><dd><code>Jaccard 기반 이슈 분류 순수 로직 스크립트</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/scripts/issue-classifier.js

<ul><li>순수 JavaScript 이슈 분류 모듈 (455줄) 추가<br> <li> 토큰 Jaccard 유사도로 중복 이슈 감지 (제목 가중치 65%, 본문 35%)<br> <li> 병합된 PR의 Closes/Fixes/Resolves 키워드 및 issue-N 브랜치 규칙으로 해결 이슈 추출<br> <li> "fixed in v2", "resolved in #123" 등 구체적 해결 신호 + 일반 해결 표현 감지<br> <li> 부정의 표현("not fixed", "still happening") 가드<br> <li> CLI 모드 지원 (pytest 래퍼와 함께 로컬 QA 가능)<br> <li> Dry-run,閾値 설정 등 설정 가능한 파라미터 제공</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/199/files#diff-5bffd9d1b562279c88ec118de43fff216f196b1b6280f029559a29215aa37852">+455/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>91_issue-classification.yml</strong><dd><code>이슈 자동 분류 GitHub Actions 워크플로우</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/91_issue-classification.yml

<ul><li>4개 잡의 GitHub Actions 워크플로우 추가 (544줄)<br> <li> duplicate-classification: 새/편집된 이슈의 중복 감지, <code>duplicate</code> 라벨 + 유사 이슈 링크<br> <li> resolved-from-merged-pr: PR 병합 시 Closes/Fixes/Resolves한 이슈에 <code>resolved</code> <br>라벨<br> <li> resolved-from-signal: 텍스트 해결 신호 감지 시 <code>resolved</code> 라벨 (닫기 옵션)<br> <li> resolved-sweep: 매일 1:30 스케줄, 아직 닫히지 않은 해결된 이슈 스위프<br> <li> 모든 잡에서 이전 코멘트 중복 방지 HTML 마커 사용<br> <li> workflow_dispatch로 dry-run 및 파라미터 수동 조정 가능</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/199/files#diff-925a942cf5a654079bece14ac3b1117622177ca4276c6bdc6cde64a0f9e34954">+544/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

