### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/06_codeql.yml
+++ b/.github/workflows/06_codeql.yml
@@ -60,4 +60,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-on-failure
         with:
-          title: '🚨 CodeQL Analysis Failed: ${{ github.run_id }}'
+          title: '🚨 CodeQL Analysis Failed'

--- a/.github/workflows/37_ci-failure-issues.yml
+++ b/.github/workflows/37_ci-failure-issues.yml
@@ -9,8 +9,22 @@ name: CI Failure Issues
 
 on:
   workflow_run:
-    workflows: ["Sanity", "Auto Deploy Workflows", "PR Checks"]
+    workflows:
+      - "Sanity"
+      - "Auto Deploy Workflows"
+      - "PR Checks"
+      - "Gitleaks"
+      - "Runtime Health Check"
+      - "ELK Health Check"
+      - "Downstream Health Check"
+      - "Bot Health Monitor"
+      - "Drift Detector"
+      - "CI Auto-Heal"
     types: [completed]
+  schedule:
+    # Daily stale-failure-issue sweep: close failure/health issues whose
+    # originating workflow has since recovered (latest master run == success).
+    - cron: "45 5 * * *"  # 05:45 UTC daily (offset from other crons)
   workflow_dispatch:
     inputs:
       workflow_name:
@@ -52,6 +66,9 @@ concurrency:
 
 jobs:
   triage:
+    # The event-driven path handles workflow_run + manual dispatch. The daily
+    # schedule is handled by the separate `sweep` job below.
+    if: github.event_name != 'schedule'
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 5
     # Trigger only on FAILURE conclusion (success → close stale below).
@@ -236,3 +253,79 @@ jobs:
       - name: Notify on failure
         if: failure()
         uses: ./.github/actions/notify-on-failure
+
+  # Daily sweep: auto-close stale failure/health issues whose originating
+  # workflow has since recovered. Maps each open issue to its workflow file by
+  # title pattern, queries that workflow's latest COMPLETED run on the default
+  # branch, and closes the issue when the latest run conclusion is success.
+  # This is the safety-net layer for issues the event-driven path missed
+  # (missed webhooks, renamed workflows, legacy per-run-id-titled issues).
+  sweep:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - name: Sweep stale failure/health issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'master' }}
+        run: |
+          set -euo pipefail
+          # Map a title-substring -> workflow file. A stale issue whose title
+          # contains the key is auto-closed iff that workflow's latest
+          # completed run on the default branch concluded 'success'.
+          # Format: '<title-substring>|<workflow-file>'
+          MAP="$(printf '%s\n' \
+            'Gitleaks Scan Failed|05_gitleaks.yml' \
+            'Runtime Health Check failed|30_runtime-health-check.yml' \
+            'ELK Health Check Failed|26_elk-health-check.yml' \
+            'Downstream Health Check failed|29_downstream-health-check.yml' \
+            'Bot Health|28_bot-health-monitor.yml' \
+            'CI Auto-Heal failed|60_ci-auto-heal.yml' \
+            'Repository Health Check|31_repo-health.yml')"
+
+          # Cache each workflow's latest completed run conclusion.
+          latest_conclusion() {
+            wf_file="$1"
+            # Query-string form forces a GET; -f would make gh send a POST (404).
+            gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$wf_file/runs?branch=$DEFAULT_BRANCH&status=completed&per_page=1" \
+              --jq '.workflow_runs[0].conclusion // "none"' 2>/dev/null || echo "error"
+          }
+
+          # Note: the loop runs in a pipeline subshell, so per-close logging
+          printf '%s\n' "$MAP" | while IFS='|' read -r substr wf_file; do
+            [ -z "$substr" ] && continue
+            # Find open issues whose title contains the substring.
+            issues=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+              --search "in:title \"$substr\"" --limit 100 \
+              --json number,title --jq '.[].number' 2>/dev/null || true)
+            [ -z "$issues" ] && continue
+            conclusion=$(latest_conclusion "$wf_file")
+            if [ "$conclusion" != "success" ]; then
+              echo "::notice::$wf_file latest run conclusion=$conclusion; keeping its open issues"
+              continue
+            fi
+            for n in $issues; do
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "::notice::DRY-RUN: would close #$n (workflow $wf_file recovered)"
+                continue
+              fi
+              if gh issue close "$n" --repo "$GITHUB_REPOSITORY" \
+                --comment "Auto-closed by the stale-failure sweep: $wf_file latest run on $DEFAULT_BRANCH concluded success, so this failure issue is resolved." \
+                --reason completed; then
+                echo "::notice::Closed stale issue #$n ($wf_file recovered)"
+              else
+                echo "::warning::failed to close #$n; continuing"
+              fi
+            done
+          done
+          echo "::notice::Stale-failure sweep complete"

--- a/.github/workflows/45_reusable-gitleaks.yml
+++ b/.github/workflows/45_reusable-gitleaks.yml
@@ -79,4 +79,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-on-failure
         with:
-          title: '🚨 Gitleaks Scan Failed: ${{ github.run_id }}'
+          title: '🚨 Gitleaks Scan Failed'


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 실패 이슈 자동 정리 강화

- 추가 워크플로우 실패 감지

- 알림 제목 중복 기준 안정화


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["워크플로우 실패 감지"] --> B["실패 이슈 생성 또는 댓글 추가"]
  C["일일 스케줄 실행"] --> D["최신 기본 브랜치 실행 확인"]
  D --> E["성공 시 오래된 이슈 자동 종료"]
  F["고정 알림 제목"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>06_codeql.yml</strong><dd><code>CodeQL 실패 알림 제목 고정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/06_codeql.yml

- CodeQL 실패 알림 제목에서 `github.run_id` 제거
- 실패 이슈 중복 판단에 사용할 제목을 고정화


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/221/files#diff-8096e35558e697079751a0ea2cef1d7e35451b01b96acc71112501756fed1d37">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>45_reusable-gitleaks.yml</strong><dd><code>Gitleaks 실패 알림 제목 고정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/45_reusable-gitleaks.yml

<ul><li>Gitleaks 실패 알림 제목에서 <code>github.run_id</code> 제거<br> <li> 동일 실패 유형의 이슈 중복 생성을 줄이도록 제목 안정화</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/221/files#diff-b0c214cbba4f66a13fff736b9ecc79f46a529587bb37cb1ced1d6c7c60f062c7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>37_ci-failure-issues.yml</strong><dd><code>실패 이슈 감지 및 자동 정리 확장</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/37_ci-failure-issues.yml

<ul><li>실패 감지 대상 워크플로우에 보안, 헬스체크, 자동복구 작업 추가<br> <li> 매일 실행되는 stale failure issue sweep 스케줄 추가<br> <li> 복구된 워크플로우의 열린 실패/헬스 이슈 자동 종료<br> <li> 수동 실행과 dry-run을 지원하는 sweep 작업 구성</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/221/files#diff-b7915627bf5a3f819200e450f76d18990ded0c290cd731ef75bbb887a26bc3f9">+94/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

