### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/13_pr-auto-merge.yml
+++ b/.github/workflows/13_pr-auto-merge.yml
@@ -119,8 +119,17 @@ jobs:
           fi
           # GitHub auto-merge only fires once all required status checks pass
           # and the merge box is green. We just enable it; we never bypass.
-          gh pr merge --auto --squash "$PR_URL" \
-            || echo "::warning::auto-merge enable failed (allow_auto_merge disabled, branch protection mismatch, or PR already merged); not retrying"
+          # Tolerate ONLY the "already merged/closed" race; surface every other
+          # failure (allow_auto_merge disabled, branch-protection mismatch) so
+          # the run does not silently report success on a broken automation.
+          if ! err=$(gh pr merge --auto --squash "$PR_URL" 2>&1); then
+            if printf '%s' "$err" | grep -qiE 'already merged|not mergeable: the merge commit cannot be created|pull request is closed|already been merged'; then
+              echo "::notice::auto-merge no-op: PR already merged/closed — $err"
+            else
+              echo "::error::auto-merge enable failed: $err"
+              exit 1
+            fi
+          fi
 
       - name: Self-heal stale BLOCKED PR
         # If checks pass but GitHub reports mergeStateStatus=BLOCKED, the PR's


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 이미 병합/종료된 PR 경쟁 조건은 무시 처리

- 브랜치 보호 및 auto-merge 설정 오류는 실패 처리

- `gh pr merge` 실패 시 조건부 로깅과 종료 처리


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MERGE["gh pr merge --auto 실행"] --> CHECK{"오류 발생?"}
  CHECK -- "이미 병합/종료" --> NOTICE["::notice:: 무시"]
  CHECK -- "기타 실패" --> FAIL["::error:: 종료 코드 1"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>13_pr-auto-merge.yml</strong><dd><code>auto-merge 단계의 오류 처리 강화</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/13_pr-auto-merge.yml

<ul><li><code>gh pr merge</code> 표준에러 출력을 변수에 저장하여 후속 분석 가능하게 변경<br> <li> 이미 병합되었거나 종료된 PR 관련 경쟁 조건은 <code>::notice::</code>로 기록하고 통과 처리<br> <li> <code>allow_auto_merge</code> 비활성화, 브랜치 보호 정책 불일치 등 실제 오류는 <code>::error::</code>로 기록하고 종료 코드 1 <br>반환<br> <li> 기존의 무조건적 경고 출력을 조건부 판단 로직으로 대체</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/251/files#diff-4e6c997fec11c213c0cd8b8ea0c14b64a9035ded963b007285e261d2aab0c435">+11/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

