### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/01_branch-to-pr.yml
+++ b/.github/workflows/01_branch-to-pr.yml
@@ -65,6 +65,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       - name: Compute PR metadata
         id: meta
@@ -101,8 +105,33 @@ jobs:
           LAST_COMMIT=$(git log -1 --pretty=format:%s "origin/$BRANCH" 2>/dev/null || git log -1 --pretty=format:%s)
           echo "title=$LAST_COMMIT" >> "$GITHUB_OUTPUT"
 
+      - name: LLM branch-to-PR decision (DP-15)
+        id: llm
+        env:
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          BRANCH: ${{ steps.meta.outputs.branch }}
+          BASE: ${{ steps.meta.outputs.base }}
+          TITLE: ${{ steps.meta.outputs.title }}
+          ISSUE_NUM: ${{ steps.meta.outputs.issue_number }}
+        run: |
+          set -eu
+          if [ "${{ steps.meta.outputs.skip }}" = "true" ]; then
+            {
+              echo "ok=true"
+              echo "action=noop"
+              echo "requires_human=false"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git log --pretty=format:'%s (%h)' -n 10 "origin/${BRANCH}" > "${RUNNER_TEMP}/branch-commits.txt" 2>/dev/null || true
+          python3 -c "import json,os; json.dump({'branch':os.environ.get('BRANCH',''),'base':os.environ.get('BASE',''),'title':os.environ.get('TITLE',''),'issue_number':os.environ.get('ISSUE_NUM',''),'commits':open(os.environ['RUNNER_TEMP'] + '/branch-commits.txt', encoding='utf-8').read()}, open(os.environ['RUNNER_TEMP'] + '/branch-to-pr-input.json','w'))"
+          python3 scripts/llm_decide.py \
+            --decision-type branch-to-pr \
+            --input "${RUNNER_TEMP}/branch-to-pr-input.json" \
+            --output "$GITHUB_OUTPUT" || true
+
       - name: Open draft PR
-        if: steps.meta.outputs.skip != 'true'
+        if: steps.meta.outputs.skip != 'true' && (steps.llm.outputs.ok != 'true' || steps.llm.outputs.action == 'open')
         env:
           # Use GH_PAT (falls back to GITHUB_TOKEN) so the created PR triggers
           # downstream 'pull_request' workflows. PRs opened with the default

--- a/.github/workflows/14_bot-auto-fix.yml
+++ b/.github/workflows/14_bot-auto-fix.yml
@@ -44,6 +44,10 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.21'
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       - name: Run naming validator with --fix
         id: fix
@@ -71,8 +75,25 @@ jobs:
             git diff --stat
           fi
 
-      - name: Push fixes back to PR
+      - name: LLM bot auto-fix push decision (DP-12/13)
+        id: llm
         if: steps.check.outputs.has_changes == 'true'
+        env:
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -eu
+          git diff --stat > "${RUNNER_TEMP}/bot-auto-fix.diffstat" || true
+          python3 -c "import json,os; json.dump({'title':os.environ.get('PR_TITLE',''),'branch':os.environ.get('PR_BRANCH',''),'author':os.environ.get('PR_AUTHOR',''),'diffstat':open(os.environ['RUNNER_TEMP'] + '/bot-auto-fix.diffstat', encoding='utf-8').read()}, open(os.environ['RUNNER_TEMP'] + '/bot-auto-fix-input.json','w'))"
+          python3 scripts/llm_decide.py \
+            --decision-type bot-auto-fix \
+            --input "${RUNNER_TEMP}/bot-auto-fix-input.json" \
+            --output "$GITHUB_OUTPUT" || true
+
+      - name: Push fixes back to PR
+        if: steps.check.outputs.has_changes == 'true' && steps.llm.outputs.ok == 'true' && steps.llm.outputs.action == 'push' && steps.llm.outputs.requires_human != 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
           GITHUB_TOKEN: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/37_ci-failure-issues.yml
+++ b/.github/workflows/37_ci-failure-issues.yml
@@ -245,6 +245,36 @@ jobs:
           gh label create ci-failure --color B60205 --description "Auto-managed by ci-failure-issues.yml" 2>/dev/null || true
           gh label create automated --color BFD4F2 --description "Auto-managed by jclee-bot" 2>/dev/null || true
 
+      - name: Checkout
+        if: steps.ev.outputs.conclusion == 'failure'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python 3.12
+        if: steps.ev.outputs.conclusion == 'failure'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: LLM CI failure issue decision (DP-9)
+        if: steps.ev.outputs.conclusion == 'failure'
+        id: llm
+        env:
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          WF_NAME: ${{ steps.ev.outputs.wf_name }}
+          HEAD_SHA: ${{ steps.ev.outputs.head_sha }}
+          SHORT_SHA: ${{ steps.ev.outputs.short_sha }}
+          RUN_ID: ${{ steps.ev.outputs.run_id }}
+          PR_NUMBER: ${{ steps.ev.outputs.pr_number }}
+        run: |
+          set -eu
+          python3 -c "import json,os; json.dump({'workflow':os.environ['WF_NAME'],'head_sha':os.environ['HEAD_SHA'],'short_sha':os.environ['SHORT_SHA'],'run_id':os.environ['RUN_ID'],'pr_number':os.environ['PR_NUMBER'],'title':'[ci] '+os.environ['WF_NAME']+' failed at '+os.environ['SHORT_SHA']}, open(os.environ['RUNNER_TEMP'] + '/ci-failure-issue-input.json','w'))"
+          python3 scripts/llm_decide.py \
+            --decision-type ci-failure-issue \
+            --input "${RUNNER_TEMP}/ci-failure-issue-input.json" \
+            --output "$GITHUB_OUTPUT" || true
+
       - name: Find or create issue for failure
         if: steps.ev.outputs.conclusion == 'failure'
         env:
@@ -255,9 +285,15 @@ jobs:
           RUN_ID: ${{ steps.ev.outputs.run_id }}
           PR_NUMBER: ${{ steps.ev.outputs.pr_number }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          LLM_OK: ${{ steps.llm.outputs.ok }}
+          LLM_ACTION: ${{ steps.llm.outputs.action }}
         run: |
           set -eu
           TITLE="[ci] $WF_NAME failed at $SHORT_SHA"
+          if [ "$LLM_OK" = "true" ] && [ "$LLM_ACTION" != "create" ]; then
+            echo "::notice::LLM chose '$LLM_ACTION'; skipping ci-failure issue creation"
+            exit 0
+          fi
           # Idempotency: search for an open issue with the SAME title.
           # Compare exact title rather than substring to avoid false matches.
           EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/60_ci-auto-heal.yml
+++ b/.github/workflows/60_ci-auto-heal.yml
@@ -25,11 +25,22 @@ jobs:
           terraform version 2>/dev/null || echo "terraform not available"
           node --version
           go version 2>/dev/null || echo "go not available"
+      - name: Checkout decision helper
+        uses: actions/checkout@v6
+        with:
+          path: _bot-scripts
+          fetch-depth: 1
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Auto-heal failed CI across repos
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: |
           set -eu
+          HELPER="$GITHUB_WORKSPACE/_bot-scripts/scripts/llm_decide.py"
           REPOS="account blacklist bug hycu_fsds idle-outpost opencode resume safetywallet splunk terraform tmux"
           HEAL_COUNT=0
           ISSUE_COUNT=0
@@ -64,8 +75,29 @@ jobs:
               cd "$TEMP_DIR"
               FIXED=false
               FIX_SUMMARY=""
-              if [ -f "package.json" ]; then
-                if echo "$WF_NAME" | grep -qiE "audit|dependency|security|npm"; then
+              HAS_PACKAGE_JSON=false
+              HAS_PACKAGE_LOCK=false
+              HAS_GO_MOD=false
+              HAS_TERRAFORM=false
+              HAS_PYTHON=false
+              [ -f "package.json" ] && HAS_PACKAGE_JSON=true
+              [ -f "package-lock.json" ] && HAS_PACKAGE_LOCK=true
+              [ -f "go.mod" ] && HAS_GO_MOD=true
+              if ls ./*.tf >/dev/null 2>&1; then HAS_TERRAFORM=true; fi
+              if [ -f "requirements.txt" ] || [ -f "pyproject.toml" ] || [ -f "setup.py" ]; then HAS_PYTHON=true; fi
+              LLM_INPUT="${RUNNER_TEMP}/ci-auto-heal-${REPO_NAME}-${RUN_ID}.json"
+              LLM_OUTPUT="${RUNNER_TEMP}/ci-auto-heal-${REPO_NAME}-${RUN_ID}.out"
+              export FULL REPO_NAME RUN_ID WF_NAME BRANCH HAS_PACKAGE_JSON HAS_PACKAGE_LOCK HAS_GO_MOD HAS_TERRAFORM HAS_PYTHON LLM_INPUT
+              python3 -c "import json,os; json.dump({'repo':os.environ['FULL'],'run_id':os.environ['RUN_ID'],'workflow':os.environ['WF_NAME'],'branch':os.environ['BRANCH'],'files':{'package_json':os.environ['HAS_PACKAGE_JSON']=='true','package_lock':os.environ['HAS_PACKAGE_LOCK']=='true','go_mod':os.environ['HAS_GO_MOD']=='true','terraform':os.environ['HAS_TERRAFORM']=='true','python':os.environ['HAS_PYTHON']=='true'}}, open(os.environ['LLM_INPUT'],'w'))" || true
+              python3 "$HELPER" --decision-type ci-auto-heal --input "$LLM_INPUT" --output "$LLM_OUTPUT" || true
+              LLM_OK=$(grep '^ok=' "$LLM_OUTPUT" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+              LLM_ACTION=$(grep '^action=' "$LLM_OUTPUT" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+              LLM_COMMAND=$(grep '^command=' "$LLM_OUTPUT" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+              LLM_REQUIRES_HUMAN=$(grep '^requires_human=' "$LLM_OUTPUT" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+              if [ "$LLM_OK" != "true" ] || [ "$LLM_ACTION" != "command" ] || [ "$LLM_REQUIRES_HUMAN" = "true" ]; then
+                echo "   LLM did not authorize auto-heal; fail-closed"
+              elif [ -f "package.json" ]; then
+                if [ "$LLM_COMMAND" = "npm-audit-fix" ] && echo "$WF_NAME" | grep -qiE "audit|dependency|security|npm"; then
                   echo "   Attempting npm audit fix"
                   if npm audit fix --package-lock-only 2>/dev/null; then
                     FIXED=true
@@ -75,7 +107,7 @@ jobs:
                     FIX_SUMMARY="$FIX_SUMMARY\n- npm audit fix (with package-lock generation)"
                   fi
                 fi
-                if echo "$WF_NAME" | grep -qiE "lint|prettier|format|style"; then
+                if [ "$LLM_COMMAND" = "npm-lint-fix" ] && echo "$WF_NAME" | grep -qiE "lint|prettier|format|style"; then
                   echo "   Attempting lint/format fixes"
                   if npm run lint:fix 2>/dev/null; then
                     FIXED=true
@@ -85,7 +117,7 @@ jobs:
                     FIX_SUMMARY="$FIX_SUMMARY\n- prettier --write"
                   fi
                 fi
-                if [ "$FIXED" != "true" ] && [ -f "package-lock.json" ]; then
+                if [ "$LLM_COMMAND" = "npm-update" ] && [ "$FIXED" != "true" ] && [ -f "package-lock.json" ]; then
                   echo "   Attempting npm update"
                   if npm update --package-lock-only 2>/dev/null; then
                     FIXED=true
@@ -93,8 +125,8 @@ jobs:
                   fi
                 fi
               fi
-              if [ -f "go.mod" ]; then
-                if echo "$WF_NAME" | grep -qiE "go|mod|tidy|build|test"; then
+              if [ "$LLM_OK" = "true" ] && [ "$LLM_ACTION" = "command" ] && [ "$LLM_REQUIRES_HUMAN" != "true" ] && [ -f "go.mod" ]; then
+                if [ "$LLM_COMMAND" = "go-mod-tidy" ] && echo "$WF_NAME" | grep -qiE "go|mod|tidy|build|test"; then
                   echo "   Attempting go mod tidy"
                   if go mod tidy 2>/dev/null; then
                     FIXED=true
@@ -102,8 +134,8 @@ jobs:
                   fi
                 fi
               fi
-              if ls ./*.tf >/dev/null 2>&1; then
-                if echo "$WF_NAME" | grep -qiE "terraform|fmt|validate"; then
+              if [ "$LLM_OK" = "true" ] && [ "$LLM_ACTION" = "command" ] && [ "$LLM_REQUIRES_HUMAN" != "true" ] && ls ./*.tf >/dev/null 2>&1; then
+                if [ "$LLM_COMMAND" = "terraform-fmt" ] && echo "$WF_NAME" | grep -qiE "terraform|fmt|validate"; then
                   echo "   Attempting terraform fmt"
                   if terraform fmt -recursive 2>/dev/null; then
                     FIXED=true
@@ -111,13 +143,16 @@ jobs:
                   fi
                 fi
               fi
-              if [ -f "requirements.txt" ] || [ -f "pyproject.toml" ] || [ -f "setup.py" ]; then
-                if echo "$WF_NAME" | grep -qiE "python|lint|ruff|black|format"; then
+              if [ "$LLM_OK" = "true" ] && [ "$LLM_ACTION" = "command" ] && [ "$LLM_REQUIRES_HUMAN" != "true" ] && { [ -f "requirements.txt" ] || [ -f "pyproject.toml" ] || [ -f "setup.py" ]; }; then
+                if [ "$LLM_COMMAND" = "ruff-fix" ] && echo "$WF_NAME" | grep -qiE "python|lint|ruff|black|format"; then
                   echo "   Attempting Python format fixes"
                   if ruff check --fix . 2>/dev/null; then
                     FIXED=true
                     FIX_SUMMARY="$FIX_SUMMARY\n- ruff check --fix"
-                  elif black . 2>/dev/null; then
+                  fi
+                elif [ "$LLM_COMMAND" = "black-format" ] && echo "$WF_NAME" | grep -qiE "python|lint|ruff|black|format"; then
+                  echo "   Attempting Python format fixes"
+                  if black . 2>/dev/null; then
                     FIXED=true
                     FIX_SUMMARY="$FIX_SUMMARY\n- black ."
                   fi

--- a/.github/workflows/91_issue-classification.yml
+++ b/.github/workflows/91_issue-classification.yml
@@ -101,8 +101,45 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: LLM duplicate decision (DP-3)
+        id: llm
+        env:
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_JSON: ${{ toJson(github.event.issue) }}
+        run: |
+          set -eu
+          python3 - <<'PY'
+          import json, os, subprocess
+
+          issue = json.loads(os.environ.get('ISSUE_JSON') or '{}')
+          candidates = []
+          try:
+              raw = subprocess.check_output([
+                  'gh', 'api', f"repos/{os.environ['GITHUB_REPOSITORY']}/issues?state=open&per_page=100",
+                  '--paginate'
+              ], text=True)
+              candidates = json.loads(raw)
+          except Exception:
+              candidates = []
+          payload = {'issue': issue, 'candidates': candidates}
+          with open(os.environ['RUNNER_TEMP'] + '/issue-classify-duplicate-input.json', 'w', encoding='utf-8') as f:
+              json.dump(payload, f)
+          PY
+          python3 scripts/llm_decide.py \
+            --decision-type issue-classify \
+            --input "${RUNNER_TEMP}/issue-classify-duplicate-input.json" \
+            --output "$GITHUB_OUTPUT" || true
       - name: Classify duplicate issue
         uses: actions/github-script@v9
+        env:
+          LLM_OK: ${{ steps.llm.outputs.ok }}
+          LLM_ACTION: ${{ steps.llm.outputs.action }}
+          LLM_REASON: ${{ steps.llm.outputs.reason }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -134,6 +171,42 @@ jobs:
             if (!issue || issue.pull_request) {
               core.info('Not an issue payload; skipping.');
               return;
+            }
+
+            if (process.env.LLM_OK === 'true') {
+              core.info(`#${issue.number}: LLM issue-classify action=${process.env.LLM_ACTION} reason=${process.env.LLM_REASON || ''}`);
+              if (process.env.LLM_ACTION === 'noop' || process.env.LLM_ACTION === 'resolved') {
+                return;
+              }
+              if (process.env.LLM_ACTION === 'duplicate') {
+                if (cfg.dryRun) {
+                  core.notice(`[dry-run] LLM would label #${issue.number} duplicate.`);
+                  return;
+                }
+                await ensureLabel('duplicate', 'cfd3d7', 'Auto-classified: possible duplicate');
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: ['duplicate'],
+                });
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  per_page: 100,
+                });
+                const already = comments.some(c => c.body && c.body.includes(classifier.DUP_MARKER));
+                if (!already) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: `${classifier.DUP_MARKER}\n\nLLM classified this issue as a possible duplicate.\n\nReason: ${process.env.LLM_REASON || 'No reason provided.'}`,
+                  });
+                }
+                return;
+              }
             }
 
             const candidates = await github.paginate(github.rest.issues.listForRepo, {
@@ -323,8 +396,38 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: LLM resolved-signal decision (DP-4)
+        id: llm
+        env:
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          ISSUE_JSON: ${{ toJson(github.event.issue) }}
+          COMMENT_JSON: ${{ toJson(github.event.comment) }}
+        run: |
+          set -eu
+          python3 - <<'PY'
+          import json, os
+
+          payload = {
+              'issue': json.loads(os.environ.get('ISSUE_JSON') or '{}'),
+              'comment': json.loads(os.environ.get('COMMENT_JSON') or 'null'),
+          }
+          with open(os.environ['RUNNER_TEMP'] + '/issue-classify-resolved-input.json', 'w', encoding='utf-8') as f:
+              json.dump(payload, f)
+          PY
+          python3 scripts/llm_decide.py \
+            --decision-type issue-classify \
+            --input "${RUNNER_TEMP}/issue-classify-resolved-input.json" \
+            --output "$GITHUB_OUTPUT" || true
       - name: Detect resolved signal
         uses: actions/github-script@v9
+        env:
+          LLM_OK: ${{ steps.llm.outputs.ok }}
+          LLM_ACTION: ${{ steps.llm.outputs.action }}
+          LLM_REASON: ${{ steps.llm.outputs.reason }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -355,6 +458,42 @@ jobs:
             if (issue.state === 'closed') {
               core.info(`#${issue.number} already closed; skipping.`);
               return;
+            }
+
+            if (process.env.LLM_OK === 'true') {
+              core.info(`#${issue.number}: LLM issue-classify action=${process.env.LLM_ACTION} reason=${process.env.LLM_REASON || ''}`);
+              if (process.env.LLM_ACTION === 'noop' || process.env.LLM_ACTION === 'duplicate') {
+                return;
+              }
+              if (process.env.LLM_ACTION === 'resolved') {
+                if (cfg.dryRun) {
+                  core.notice(`[dry-run] LLM would mark #${issue.number} resolved.`);
+                  return;
+                }
+                await ensureLabel('resolved', '0e8a16', 'Auto-classified: issue resolved');
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: ['resolved'],
+                });
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  per_page: 100,
+                });
+                const already = comments.some(c => c.body && c.body.includes(classifier.RESOLVED_MARKER));
+                if (!already) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: `${classifier.RESOLVED_MARKER}\n\nLLM classified this issue as resolved.\n\nReason: ${process.env.LLM_REASON || 'No reason provided.'}`,
+                  });
+                }
+                return;
+              }
             }
 
             // Consider the issue body plus the triggering comment (if any).


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- 5개 워크플로우에 LLM 기반 결정 게이트 추가

- branch-to-pr, bot-fix, CI 힐링 등 AI 의사결정 적용

- Python 3.12 런타임 및 의존성 설치 추가

- 이슈 중복/해결 신호 자동 분류 기능 강화


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub 이벤트 발생"] --> B["Python 3.12 환경 구성"]
  B --> C["scripts/llm_decide.py 실행"]
  C --> D{"Minimax LLM 판단"}
  D -- "승인" --> E["자동 작업 수행"]
  D -- "거부/수동필요" --> F["작업 중단 또는 대기"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>01_branch-to-pr.yml</strong><dd><code>branch-to-pr 워크플로우에 LLM 결정 게이트 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/01_branch-to-pr.yml

<ul><li><code>actions/setup-python@v5</code>를 추가해 Python 3.12 런타임을 구성<br> <li> <code>LLM branch-to-PR decision</code> 단계에서 <code>scripts/llm_decide.py</code>를 호출<br> <li> PR 생성 조건에 <code>steps.llm.outputs.action == 'open'</code>을 추가해 LLM 승인 시에만 오픈</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/255/files#diff-2b8ecfd59845f64ef3ff1198ff2bcdabb8e782622b3b2b06c0402c4b45a08f16">+30/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>14_bot-auto-fix.yml</strong><dd><code>bot-auto-fix 워크플로우에 LLM push 승인 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/14_bot-auto-fix.yml

<ul><li>Python 3.12 실행 환경 설정 추가<br> <li> 수정분 생성 후 <code>LLM bot auto-fix push decision</code> 단계로 push 여부를 LLM에 문의<br> <li> fix push 조건에 <code>ok==true && action==push && requires_human!=true</code>를 적용해 <br>안전하게 제어</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/255/files#diff-e594d8670707ce5ac3fa2b465eed7ddf1c669ba5d731b72d369d7166ffcb7d28">+22/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>37_ci-failure-issues.yml</strong><dd><code>CI 실패 이슈 생성에 LLM 판단 게이트 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/37_ci-failure-issues.yml

<ul><li>CI 실패 시 Python 3.12 설치 및 <code>LLM CI failure issue decision</code> 단계 추가<br> <li> LLM <code>action</code>이 <code>create</code>가 아니면 이슈 생성을 건너뜀<br> <li> 후속 스크립트 단계에서 <code>LLM_OK</code>, <code>LLM_ACTION</code> 환경변수를 참조해 분기 처리</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/255/files#diff-b7915627bf5a3f819200e450f76d18990ded0c290cd731ef75bbb887a26bc3f9">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>60_ci-auto-heal.yml</strong><dd><code>ci-auto-heal 워크플로우에 LLM 기반 복구 승인 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/60_ci-auto-heal.yml

<ul><li><code>_bot-scripts</code> 경로로 저장소를 체크아웃하고 Python 3.12를 설정<br> <li> <code>package.json</code>, <code>go.mod</code>, <code>.tf</code>, Python 매니페스트 존재 여부를 JSON로 만들어 LLM에 전달<br> <li> LLM이 <code>ok=true && action=command && requires_human!=true</code>인 경우에만 지정된 명령어를 <br>실행하는 fail-closed 로직 적용</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/255/files#diff-9dcf0b5c34b1734903099272c2aa06e279f03d19efb5bf508c4121cadb00ed00">+46/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>91_issue-classification.yml</strong><dd><code>issue-classification 워크플로우에 LLM 중복/해결 분류 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/91_issue-classification.yml

<ul><li>이슈 생성/코멘트 시 Python 3.12 환경에서 <code>llm_decide.py</code>를 실행하는 단계 추가<br> <li> LLM이 <code>duplicate</code>로 분류하면 <code>duplicate</code> 라벨과 안내 코멘트를 자동 추가<br> <li> LLM이 <code>resolved</code>로 분류하면 <code>resolved</code> 라벨과 코멘트를 추가하고 기존 rule 기반 로직은 우회 처리</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/255/files#diff-925a942cf5a654079bece14ac3b1117622177ca4276c6bdc6cde64a0f9e34954">+139/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

