### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/actions/notify-on-failure/action.yml
+++ b/.github/actions/notify-on-failure/action.yml
@@ -1,0 +1,69 @@
+name: Notify on failure
+description: >-
+  Create or comment on a deduplicated GitHub issue when a workflow step fails.
+  De-dupes by (workflow name, head sha) so re-runs and matrix legs share a
+  single issue rather than fanning out new ones per run.
+
+inputs:
+  title:
+    description: Issue title (default = "[ci-fail] <workflow> @ <short_sha>")
+    required: false
+    default: ''
+  body:
+    description: Issue body markdown (default includes workflow + run link)
+    required: false
+    default: ''
+  labels:
+    description: Comma-separated extra labels to add (always combined with `ci-failure`)
+    required: false
+    default: ''
+  github-token:
+    description: Token used to read/write issues
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create or update failure issue
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        INPUT_TITLE: ${{ inputs.title }}
+        INPUT_BODY: ${{ inputs.body }}
+        INPUT_LABELS: ${{ inputs.labels }}
+        WF_NAME: ${{ github.workflow }}
+        HEAD_SHA: ${{ github.sha }}
+        RUN_ID: ${{ github.run_id }}
+        SERVER_URL: ${{ github.server_url }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -eu
+        SHORT_SHA="${HEAD_SHA:0:8}"
+        TITLE="${INPUT_TITLE:-[ci-fail] $WF_NAME @ $SHORT_SHA}"
+        RUN_URL="$SERVER_URL/$REPO/actions/runs/$RUN_ID"
+        BODY="${INPUT_BODY:-$WF_NAME workflow failed on \`$HEAD_SHA\`. See [run logs]($RUN_URL).}"
+
+        # Dedup: look for an open issue with the SAME title.
+        EXISTING=$(gh issue list --repo "$REPO" \
+          --state open --label ci-failure \
+          --json number,title \
+          --jq ".[] | select(.title == \"$TITLE\") | .number" 2>/dev/null | head -1 || true)
+
+        if [ -n "$EXISTING" ]; then
+          gh issue comment "$EXISTING" --repo "$REPO" \
+            --body "Another failure: $RUN_URL" \
+            || echo "::warning::failed to add dedup comment on #$EXISTING"
+          echo "::notice::Reused existing ci-failure issue #$EXISTING"
+        else
+          gh label create ci-failure --color B60205 --description "Auto-managed by notify-on-failure" 2>/dev/null || true
+          LABEL_ARG="ci-failure"
+          if [ -n "$INPUT_LABELS" ]; then
+            LABEL_ARG="$LABEL_ARG,$INPUT_LABELS"
+          fi
+          gh issue create --repo "$REPO" \
+            --title "$TITLE" \
+            --body "$BODY" \
+            --label "$LABEL_ARG" \
+            || echo "::warning::failed to create ci-failure issue (non-fatal)"
+        fi

--- a/.github/workflows/45_reusable-gitleaks.yml
+++ b/.github/workflows/45_reusable-gitleaks.yml
@@ -55,7 +55,22 @@ jobs:
       - name: Install gitleaks
         run: |
           set -eu
-          wget -qO /tmp/gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
+          URL="https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
+          # Self-hosted runners may lack wget; fall back to curl. Fail loudly
+          # if neither is available or the download is empty (a silent fetch
+          # failure otherwise surfaces as a confusing tar error).
+          if command -v wget >/dev/null 2>&1; then
+            wget -qO /tmp/gitleaks.tar.gz "$URL"
+          elif command -v curl >/dev/null 2>&1; then
+            curl -fsSL -o /tmp/gitleaks.tar.gz "$URL"
+          else
+            echo "::error::neither wget nor curl is available to download gitleaks" >&2
+            exit 1
+          fi
+          if [ ! -s /tmp/gitleaks.tar.gz ]; then
+            echo "::error::gitleaks download failed or produced an empty file" >&2
+            exit 1
+          fi
           mkdir -p "$HOME/.local/bin"
           tar -xzf /tmp/gitleaks.tar.gz -C "$HOME/.local/bin" gitleaks
           chmod +x "$HOME/.local/bin/gitleaks"


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
enhancement, error handling


___

### **Description**
- Add new `notify-on-failure` reusable action that auto-creates deduplicated GitHub issues on workflow failures

- Enhance gitleaks workflow with wget/curl fallback for self-hosted runners lacking wget

- Add download validation to detect empty file failures early with explicit error messages

- Auto-create `ci-failure` label (color B60205) when first issue is created


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Workflow Step Fails] --> B[notify-on-failure action]
  B --> C{Existing open issue?}
  C -->|Yes| D[Add comment to existing issue]
  C -->|No| E[Create new ci-failure issue]
  
  F[gitleaks workflow] --> G{Install gitleaks}
  G --> H{try wget}
  H -->|fail| I{try curl}
  I -->|fail| J[Error: no download tool]
  I -->|success| K{file non-empty?}
  K -->|empty| L[Error: download failed]
  K -->|valid| M[Continue]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>New notify-on-failure reusable action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/actions/notify-on-failure/action.yml

<ul><li>New reusable action that creates or comments on GitHub issues when <br>workflows fail<br> <li> Deduplicates by workflow name and head SHA to avoid duplicate issues <br>per run<br> <li> Auto-creates <code>ci-failure</code> label with color B60205 on first use<br> <li> Uses <code>gh</code> CLI for issue management with warning-level non-fatal errors</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/323/files#diff-bbdfbd5c4e542caeb452a6e63e7f5164e305533fb2082d29f34a7cdcb0933782">+69/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>45_reusable-gitleaks.yml</strong><dd><code>Enhance gitleaks download with curl fallback and validation</code></dd></summary>
<hr>

.github/workflows/45_reusable-gitleaks.yml

<ul><li>Added curl fallback when wget is unavailable (for self-hosted runners)<br> <li> Added validation to ensure downloaded file is not empty<br> <li> Improved error messages with explicit <code>::error::</code> directives</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/323/files#diff-b0c214cbba4f66a13fff736b9ecc79f46a529587bb37cb1ced1d6c7c60f062c7">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

