### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/37_ci-failure-issues.yml
+++ b/.github/workflows/37_ci-failure-issues.yml
@@ -98,8 +98,14 @@ jobs:
             echo "::error::Invalid conclusion: $CONCLUSION (must be success, failure, cancelled, or skipped)"
             exit 1
           fi
-          # For cancelled/skipped, treat as failure for issue creation purposes
-          if [[ "$CONCLUSION" == "cancelled" || "$CONCLUSION" == "skipped" ]]; then
+          # 'skipped' is NOT a failure: workflows like CI Auto-Heal have
+          # `if: ... conclusion == 'failure'` and legitimately skip when upstream
+          # succeeded. Treat it like success (close stale issues, create none).
+          if [[ "$CONCLUSION" == "skipped" ]]; then
+            CONCLUSION="success"
+          fi
+          # A cancelled run is treated as a failure for issue-creation purposes.
+          if [[ "$CONCLUSION" == "cancelled" ]]; then
             CONCLUSION="failure"
           fi
 


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix CI failure issue workflow to treat 'skipped' conclusion as success instead of failure

- 'skipped' workflows (e.g., CI Auto-Heal with conditional logic) should not trigger issue creation

- 'cancelled' runs remain treated as failures for issue creation purposes

- Updated comments to clarify the distinction between skipped and cancelled conclusions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[CI Conclusion] --> B{conclusion type?}
  B -->|skipped| C["Treat as success<br/>(no issue created)"]
  B -->|cancelled| D["Treat as failure<br/>(create issue)"]
  B -->|success| C
  B -->|failure| D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>37_ci-failure-issues.yml</strong><dd><code>Fix skipped CI conclusion handling in failure issue workflow</code></dd></summary>
<hr>

.github/workflows/37_ci-failure-issues.yml

<ul><li>Changed 'skipped' conclusion handling from failure to success<br> <li> 'skipped' workflows now close stale issues without creating new ones<br> <li> 'cancelled' runs continue to be treated as failures for issue creation<br> <li> Updated inline comments to explain the rationale for the behavior <br>change</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/347/files#diff-b7915627bf5a3f819200e450f76d18990ded0c290cd731ef75bbb887a26bc3f9">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

