### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/10_pr-review.yml
+++ b/.github/workflows/10_pr-review.yml
@@ -52,10 +52,10 @@ jobs:
           path: pr-agent-src
           fetch-depth: 1
 
-      - name: Set up Python
-        run: |
-          python3 --version
-          which python3
+      - name: Set up Python 3.12
+        uses: ./.github/actions/setup-python-compatible
+        with:
+          python-version: '3.12'
 
       - name: Cache pip dependencies
         uses: actions/cache@v5
@@ -68,7 +68,9 @@ jobs:
       - name: Install pr-agent
         working-directory: pr-agent-src
         run: |
-          python3 -m venv .venv
+          # Use the venv that setup-python-compatible put on PATH (self-hosted
+          # Debian lacks python3-venv/ensurepip, so `python3 -m venv` fails).
+          python -m venv .venv || uv venv --seed .venv
           .venv/bin/python -m pip install --upgrade pip
           .venv/bin/python -m pip install -e .
 

--- a/.github/workflows/14_bot-auto-fix.yml
+++ b/.github/workflows/14_bot-auto-fix.yml
@@ -51,6 +51,12 @@ jobs:
 
       - name: Run naming validator with --fix
         id: fix
+        env:
+          # The self-hosted runner has HOME unset, so `go env` fails with
+          # "GOCACHE is not defined and neither $XDG_CACHE_HOME nor $HOME are
+          # defined". Provide cache dirs explicitly.
+          GOCACHE: ${{ runner.temp }}/go-build
+          GOMODCACHE: ${{ runner.temp }}/go-mod
         run: |
           set -eu
           echo "Running validate-naming --fix..."


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
enhancement


___

### **Description**
- `.github/workflows/10_pr-review.yml`에서 Python 설정을 커스텀 액션 `setup-python-compatible`로 변경하고, self-hosted Debian 환경의 호환성 개선 (uv fallback 포함)

- `.github/workflows/14_bot-auto-fix.yml`에서 self-hosted runner의 HOME 미설정 문제를 해결하기 위해 GOCACHE/GOMODCACHE 환경변수 추가

- Go 및 Python 워크플로우의 캐시 디렉토리 명시적 설정으로 셀프호스팅 환경 지원 강화


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph "self-hosted runner 환경 문제"
    A1["HOME 미설정"] --> B1["GOCACHE 오류"]
    A1 --> B2["python3-venv 없음"]
  end
  subgraph "수정 사항"
    B1 --> C1["GOCACHE/GOMODCACHE 명시적 설정"]
    B2 --> C2["uv venv fallback 추가"]
  end
  subgraph "결과"
    C1 --> D1["14_bot-auto-fix.yml 정상 작동"]
    C2 --> D2["10_pr-review.yml 정상 작동"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>10_pr-review.yml</strong><dd><code>Python 환경 설정 및 venv fallback 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/10_pr-review.yml

<ul><li>Python 3.12 설정 방식을 커스텀 액션 <code>setup-python-compatible</code>로 변경<br> <li> pip 의존성 캐싱 추가 (pr-agent-src/pyproject.toml, requirements.txt 기준)<br> <li> venv 생성 실패 시 <code>uv venv --seed .venv</code> fallback 추가 (self-hosted Debian 호환성)</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/360/files#diff-e0248294e18c71b65ec8bd370fad557a9d6126473c7baca6a3df2dd574136be1">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>14_bot-auto-fix.yml</strong><dd><code>Go 빌드 캐시 환경변수 명시적 설정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/14_bot-auto-fix.yml

<ul><li>self-hosted runner에서 HOME 미설정으로 인한 GOCACHE 오류 해결<br> <li> GOCACHE와 GOMODCACHE 환경변수를 runner.temp 디렉토리로 명시적 설정</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/terraform/pull/360/files#diff-e594d8670707ce5ac3fa2b465eed7ddf1c669ba5d731b72d369d7166ffcb7d28">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

